### PR TITLE
change port name from amqp to stream to reflect use

### DIFF
--- a/config.php
+++ b/config.php
@@ -61,7 +61,7 @@ $lightpad_get_logical_load_metrics_path = '/v2/getLogicalLoadMetrics';//Path to 
 
 $buffer_length = strlen("PLUM 8888 12345678-90ab-cdef-1234-567890abcdef 8443");//Set the buffer length to what we expect to receive from a lightpad.
 
-$amqp_port = 2708;
+$stream_port = 2708;
 
 //-----------------------Plum Website Config-----------------------//
 $user_agent_header = 'User-Agent';//User agent header.

--- a/plum_lightpad_stream.php
+++ b/plum_lightpad_stream.php
@@ -17,7 +17,7 @@ if(!$lightpad_config || !$house_config)//Check to make sure both config files ha
 function lightpad_motion($lightpad_information, $signal)//Triggered when motion is detected by a switch.
 {
 	echo "Motion Detected: [".$lightpad_information['house_name']." - ".$lightpad_information['room_name']." - ".$lightpad_information['logical_load_name']."]\n";
-	
+
 	//Example - If motion detected on downstairs or theatre switches, toggle the lights.
 	//if($lightpad_information['logical_load_name'] == 'Downstairs' || $lightpad_information['logical_load_name'] == 'Theatre')
 	//{
@@ -49,7 +49,7 @@ $sockets = [];//Setup the sockets array.
 foreach($lightpad_config as $lightpad_id => $lightpad_info)//For every lightpad in the config.
 {
 	$sockets[$lightpad_id] = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);//Create a new TCP socket.
-	
+
 	if ($sockets[$lightpad_id] === false)//Check to make sure it was created correctly.
 	{
 		echo "socket_create() failed: reason: " . socket_strerror(socket_last_error()) . "\n";//Spit out an error if not.
@@ -58,8 +58,8 @@ foreach($lightpad_config as $lightpad_id => $lightpad_info)//For every lightpad 
 	{
 		echo "Socket For: ".$lightpad_info->ip." Created.\n";//Or claim success.
 	}
-	
-	$connect_result = socket_connect($sockets[$lightpad_id], $lightpad_info->ip, $amqp_port);//Connect the socket to the amqp port.
+
+	$connect_result = socket_connect($sockets[$lightpad_id], $lightpad_info->ip, $stream_port);//Connect the socket to the stream port.
 	if ($connect_result === false)//Check to make sure it connected.
 	{
 		echo "socket_connect() failed.\nReason: ($connect_result) " . socket_strerror(socket_last_error($socket)) . "\n";//Spit out an error if not.
@@ -68,7 +68,7 @@ foreach($lightpad_config as $lightpad_id => $lightpad_info)//For every lightpad 
 	{
 		echo "Socket For: ".$lightpad_info->ip." Connected.\n";//Or claim success.
 	}
-	
+
 	socket_set_nonblock($sockets[$lightpad_id]);//Set non blocking of the socket so we can read without waiting when something does change.
 }
 
@@ -80,7 +80,7 @@ while(true)
 	$except = null;
 	$timeout = null;
 	$buffer = 2048;//Leave room for a lot of messages, max is usually at most 3.
-	
+
 	if(socket_select($read, $write, $except, $timeout) > 0);//Monitor all the connections to lightpads and wait until one has sent us a message.
 	{
 		foreach($sockets as $lightpad_id => $socket)//Check every lightpad.
@@ -89,11 +89,11 @@ while(true)
 			if($message)//If there is a message...
 			{
 				$message = str_replace("\n", '', $message);//Remove newlines.
-				$message = str_replace("\r", '', $message);//Remove carriage returns. 
+				$message = str_replace("\r", '', $message);//Remove carriage returns.
 				$updates = explode(".", $message);//Set up an array and split on .
 				array_pop($updates);//Get rid of the last empty entry in the array.
 				$lightpad_information = lightpad_information($lightpad_id);//Pull all the information for this lightpad from the config.
-				
+
 				foreach($updates as $key => $update)//For every message from the lightpad
 				{
 					$data = json_decode($update);//Turn it into an object.


### PR DESCRIPTION
While playing with the Plum switch, I tried connecting an AMQP client to the port labeled AMQP in the source. It didn't work, and after talking to Plum support, found that it's not actually AMQP on that port, just a stream of activity represented as JSON objects and separated by '.\n'. 
This PR changes the variable name in the source from amqp to stream to reflect the data flowing across the port. There is no functional change, I just hope to avoid misleading future folks like me reading the code. :)